### PR TITLE
Switch to Inconsolata, which is better supported in LaTeX

### DIFF
--- a/setup.tex
+++ b/setup.tex
@@ -8,8 +8,7 @@
 \usepackage{minted}
 \usepackage{listings}
 \usepackage{upquote}
-\usepackage{fontspec}
-\setmonofont{Hack}
+\usepackage{inconsolata}
 \ifx\mymargin\undefined
 \else
 \usepackage[margin=\mymargin]{geometry}


### PR DESCRIPTION
Inconsolata is supported as an explicit package in LaTeX, making it slightly easier to handle due to packaging support.